### PR TITLE
fix(word): Fixed issue with passing length to `any.word`

### DIFF
--- a/any.js
+++ b/any.js
@@ -16,13 +16,16 @@ const DEFAULT_SIZE_RANGE = {max: 20, min: 1};
 const integer = options => chance.natural(options);
 const float = options => chance.floating(options);
 const string = options => chance.string(options);
-const word = options => chance.word({syllables: 3, ...options});
 const sentence = options => chance.sentence(options);
 const paragraph = options => chance.paragraph(options);
 const url = options => chance.url(options);
 const boolean = options => chance.bool(options);
 const email = options => chance.email(options);
 const date = () => chance.date({string: true});
+
+function word(options = {}) {
+  return options.length ? chance.word(options) : chance.word({syllables: 3, ...options});
+}
 
 function simpleObject() {
   const object = {};

--- a/test/unit/any-test.js
+++ b/test/unit/any-test.js
@@ -61,6 +61,14 @@ suite('random data generator', () => {
     assert.equal(any.word({syllables: expectedSyllables, ...options}), word);
   });
 
+  test('that length can be used', () => {
+    const word = chance.word();
+    const length = chance.integer();
+    chanceStub.word.withArgs({length, ...options}).returns(word);
+
+    assert.equal(any.word({length, ...options}), word);
+  });
+
   test('that a sentence is generated', () => {
     const sentence = chance.sentence();
     chanceStub.sentence.withArgs(options).returns(sentence);


### PR DESCRIPTION
Since we started defaulting to passing syllables we broke the ability to pass `length` as
`chance.word` does not allow passing both length & syllables.

- closes travi/any#246